### PR TITLE
Added support for ERB in cassandra.yml config file

### DIFF
--- a/lib/cassandra_migrations/config.rb
+++ b/lib/cassandra_migrations/config.rb
@@ -14,7 +14,7 @@ module CassandraMigrations
 
     def self.load_config
       begin
-        self.config = YAML.load_file(Rails.root.join("config", "cassandra.yml"))[Rails.env]
+        self.config = YAML.load(ERB.new(File.new(Rails.root.join("config", "cassandra.yml")).read).result)[Rails.env]
       
         if config.nil?
           raise Errors::MissingConfigurationError, "No configuration for #{Rails.env} environment! Complete your config/cassandra.yml."

--- a/spec/cassandra_migrations/config_spec.rb
+++ b/spec/cassandra_migrations/config_spec.rb
@@ -32,5 +32,17 @@ describe CassandraMigrations::Config do
       CassandraMigrations::Config.keyspace
     }.to raise_exception CassandraMigrations::Errors::MissingConfigurationError
   end
+  
+  it 'should allow ERB in the config file' do
+    Rails.stub(:root).and_return Pathname.new("spec/fixtures/with_erb")
+    Rails.stub(:env).and_return ActiveSupport::StringInquirer.new("test")
+    
+    CassandraMigrations::Config.keyspace.should == 'cassandra_migrations_test'
+    
+    CassandraMigrations::Config.config = nil
+    ENV.stub(:[]).with("CI").and_return("true")
+    
+    CassandraMigrations::Config.keyspace.should == 'cassandra_migrations_ci'
+  end
 end
   

--- a/spec/fixtures/with_erb/config/cassandra.yml
+++ b/spec/fixtures/with_erb/config/cassandra.yml
@@ -1,0 +1,23 @@
+development:
+  host: "127.0.0.1"
+  port: 9042
+  keyspace: "cassandra_migrations_development"
+  replication:
+    class: "SimpleStrategy"
+    replication_factor: 1
+
+test:
+  host: "127.0.0.1"
+  port: 9042
+  keyspace: <%= ENV['CI'] ? "cassandra_migrations_ci" : "cassandra_migrations_test" %>
+  replication:
+    class: "SimpleStrategy"
+    replication_factor: 1
+    
+production:
+  host: "127.0.0.1"
+  port: 9042
+  keyspace: "cassandra_migrations_production"
+  replication:
+    class: "SimpleStrategy"
+    replication_factor: 1


### PR DESCRIPTION
database.yml in Rails allows ERB snippets to do dynamic magical stuff. I ran into the situation where I needed to do the same to use a specific cassandra cluster only in the CI enviroment. This pull request implements ERB processing for cassandra.yml.
