### PR TITLE
Add support for composite partition keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ class CreatePosts < CassandraMigrations::Migration
 end
 ```
 
+To create a table with a compound partition key specify the partition keys on table creation, i.e.:
+
+```ruby
+class CreatePosts < CassandraMigrations::Migration
+  def up
+    create_table :posts, :partition_keys => [:id, :created_month], :primary_keys => [:created_at] do |p|
+      p.integer :id
+      p.string :creation_month
+      p.timestamp :created_at
+      p.string :title
+      p.text :text
+    end
+  end
+  
+  def self.down
+    drop_table :posts
+  end
+end
+```
+
 To create a table with a secondary index you add it similar to regular rails indexes, i.e.:
 
 ```ruby

--- a/lib/cassandra_migrations/migration/table_operations.rb
+++ b/lib/cassandra_migrations/migration/table_operations.rb
@@ -19,6 +19,7 @@ module CassandraMigrations
       def create_table(table_name, options = {})
         table_definition = TableDefinition.new
         table_definition.define_primary_keys(options[:primary_keys]) if options[:primary_keys]
+        table_definition.define_partition_keys(options[:partition_keys]) if options[:partition_keys]
 
         yield table_definition if block_given?
 

--- a/spec/cassandra_migrations_spec.rb
+++ b/spec/cassandra_migrations_spec.rb
@@ -164,5 +164,29 @@ describe CassandraMigrations do
       end
     end
 
+    context 'that has composite primary key' do
+      before do
+        @migration = CompositePrimaryKey.new
+      end
+      
+      it 'should produce a valid CQL create statement' do
+        @migration.up
+        expected_cql = "CREATE TABLE composite_primary_key (id uuid, a_string varchar, PRIMARY KEY(id, a_string))"
+        expect(@migration.cql).to eq(expected_cql)
+      end
+    end
+
+    context 'that has composite partition key' do
+      before do
+        @migration = CompositePartitionKey.new
+      end
+      
+      it 'should produce a valid CQL create statement' do
+        @migration.up
+        expected_cql = "CREATE TABLE composite_partition_key (id uuid, a_string varchar, a_timestamp timestamp, PRIMARY KEY((id, a_string), a_timestamp))"
+        expect(@migration.cql).to eq(expected_cql)
+      end
+    end
+
   end
 end

--- a/spec/fixtures/migrations/migrations.rb
+++ b/spec/fixtures/migrations/migrations.rb
@@ -103,3 +103,23 @@ class MigrationWithANamedSecondaryIndex < CassandraMigrations::Migration
     drop_index 'by_another_string'
   end
 end
+
+class CompositePrimaryKey < CassandraMigrations::Migration
+  def up
+    create_table :composite_primary_key, :primary_keys => [:id, :a_string] do |t|
+      t.uuid :id
+      t.string :a_string
+    end
+  end
+end
+
+class CompositePartitionKey < CassandraMigrations::Migration
+  def up
+    create_table :composite_partition_key, :partition_keys => [:id, :a_string], :primary_keys => [:id, :a_string, :a_timestamp] do |t|
+      t.uuid :id
+      t.string :a_string
+      t.timestamp :a_timestamp
+    end
+  end
+end
+


### PR DESCRIPTION
Allows partition keys to be specified explicitly via a `partition_keys` options to `#create_table`, ie:

``` ruby
create_table :posts, :partition_keys => [:id, :created_month], 
                     :primary_keys => [:id, :created_month, :created_at] do |p|
...
```

A partition key is by definition a primary key so partition keys don't have to be included in the primary keys list but they are allowed to be.
