### PR TITLE
allow any 2.0.* version of cql-rb

### DIFF
--- a/cassandra_migrations.gemspec
+++ b/cassandra_migrations.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables = ['prepare_for_cassandra']
 
   # s.add_dependency: Production dependencies
-  s.add_dependency 'cql-rb', '2.0.0.pre1'
+  s.add_dependency 'cql-rb', '~>2.0'
   s.add_dependency 'rake', '~>10'
   s.add_dependency 'rails', '>= 3.2'
   s.add_dependency 'colorize', '~>0.5'


### PR DESCRIPTION
It's currently locked to 2.0.0.pre1, which seems too strict as they move towards 2.0.0
