### PR TITLE
Allow multiple counter fields for counter table

### DIFF
--- a/lib/cassandra_migrations/migration/table_definition.rb
+++ b/lib/cassandra_migrations/migration/table_definition.rb
@@ -78,7 +78,7 @@ module CassandraMigrations
 
         if (@columns_name_type_hash.values.include? :counter)
           non_key_columns = @columns_name_type_hash.keys - @primary_keys
-          counter_columns = [@columns_name_type_hash.select { |name, type| type == :counter }.first[0]]
+          counter_columns = @columns_name_type_hash.select { |name, type| type == :counter }.keys
           if (non_key_columns - counter_columns).present?
             raise Errors::MigrationDefinitionError, 'Non key fields not allowed in tables with counter'
           end

--- a/spec/cassandra_migrations_spec.rb
+++ b/spec/cassandra_migrations_spec.rb
@@ -319,6 +319,12 @@ describe CassandraMigrations do
         expected_cql = "CREATE TABLE with_counter (id uuid, counter_value counter, PRIMARY KEY(id))"
         expect(migration.cql).to eq(expected_cql)
       end
+      it 'should produce a valid CQL create statement if there are no non-key fields except for the counter with multiple counters' do
+        migration = WithMultipleCounterColumnMigration.new
+        migration.up
+        expected_cql = "CREATE TABLE with_counter (id uuid, counter_value counter, counter_value2 counter, PRIMARY KEY(id))"
+        expect(migration.cql).to eq(expected_cql)
+      end
 
       it 'should raise an exception when there are non-key fields other than the counter' do
         migration = WrongWithCounterColumnMigration.new

--- a/spec/fixtures/migrations/migrations.rb
+++ b/spec/fixtures/migrations/migrations.rb
@@ -215,6 +215,16 @@ class WithCounterColumnMigration < CassandraMigrations::Migration
   end
 end
 
+class WithMultipleCounterColumnMigration < CassandraMigrations::Migration
+  def up
+    create_table :with_counter do |t|
+      t.uuid :id, :primary_key => true
+      t.counter :counter_value
+      t.counter :counter_value2
+    end
+  end
+end
+
 class WrongWithCounterColumnMigration < CassandraMigrations::Migration
   def up
     create_table :with_counter do |t|


### PR DESCRIPTION
Currently multiple counters can't be added to a counter table. Cassandra allows this.
