### PR TITLE
Allows nil values to be passed in from rails

### DIFF
--- a/lib/cassandra_migrations/cassandra/queries.rb
+++ b/lib/cassandra_migrations/cassandra/queries.rb
@@ -110,7 +110,7 @@ module CassandraMigrations
           hash_to_cql(value, operation)
         else
           value = value.to_s
-          if value == "nil"
+          if value == ""
             value = 'null'
           else
             value = value

--- a/lib/cassandra_migrations/cassandra/queries.rb
+++ b/lib/cassandra_migrations/cassandra/queries.rb
@@ -109,7 +109,12 @@ module CassandraMigrations
         elsif value.is_a?(Hash)
           hash_to_cql(value, operation)
         else
-          value.to_s
+          value = value.to_s
+          if value == "nil"
+            value = 'null'
+          else
+            value = value
+          end
         end
       end
 

--- a/spec/cassandra_migrations/cassandra/queries_spec.rb
+++ b/spec/cassandra_migrations/cassandra/queries_spec.rb
@@ -31,6 +31,19 @@ describe CassandraMigrations::Cassandra::Queries do
       )
     end
 
+    it 'should insert a record into the specified table with a nil value for non-string type' do
+      allow(TestQueryExecutor).to receive(:execute).with(
+      "INSERT INTO people (name, age, height_in_meters, birth_time) VALUES ('John', 24, 1.83, null)"
+      )
+
+      TestQueryExecutor.write!('people',
+      :name => 'John',
+      :age => 24,
+      :height_in_meters => 1.83,
+      :birth_time => nil
+      )
+    end
+
     it 'should set record TTL' do
       allow(TestQueryExecutor).to receive(:execute).with(
         "INSERT INTO people (name) VALUES ('John') USING TTL 3600"
@@ -82,6 +95,17 @@ describe CassandraMigrations::Cassandra::Queries do
       TestQueryExecutor.update!('people', "name = 'John'",
         :height_in_meters => 1.93,
         :birth_time => Time.new(1989, 05, 28, 8, 50, 25, 0)
+      )
+    end
+
+    it 'should update some record values with a nil value for a non-string type' do
+      allow(TestQueryExecutor).to receive(:execute).with(
+      "UPDATE people SET height_in_meters = null, birth_time = '1989-05-28 08:50:25+0000' WHERE name = 'John'"
+      )
+
+      TestQueryExecutor.update!('people', "name = 'John'",
+      :height_in_meters => nil,
+      :birth_time => Time.new(1989, 05, 28, 8, 50, 25, 0)
       )
     end
 


### PR DESCRIPTION
Looks like this fixes issue #50 

Rails passes in nil from hash as a blank and this converts that to a null that can be used in Cassandra query