### PR TITLE
Fixes typo in PR #57

### DIFF
--- a/lib/cassandra_migrations/cassandra/queries.rb
+++ b/lib/cassandra_migrations/cassandra/queries.rb
@@ -172,7 +172,7 @@ module CassandraMigrations
       end
 
       def hash_to_cql(value, operation)
-        "#{operation}{ #{value.reduce([]) {|sum, (key, value)| sum << "'#{key}': #{to_cql_value(nil, v, nil)}" }.join(", ") } }"
+        "#{operation}{ #{value.reduce([]) {|sum, (k, v)| sum << "'#{k}': #{to_cql_value(nil, v, nil)}" }.join(", ") } }"
       end
 
     end


### PR DESCRIPTION
PR #57 had a typo where it was calling a non-existing variable `v` in `to_cql_value(nil, v, nil)`.