### PR TITLE
Allows list type to be used with this gem

### DIFF
--- a/lib/cassandra_migrations/cassandra/queries.rb
+++ b/lib/cassandra_migrations/cassandra/queries.rb
@@ -127,7 +127,7 @@ module CassandraMigrations
 
       def get_column_type(table, column)
         column_info = client.execute("SELECT VALIDATOR FROM system.schema_columns WHERE keyspace_name = '#{client.keyspace}' AND columnfamily_name = '#{table}' AND column_name = '#{column}'")
-        SYMBOL_FOR_TYPE[column_info.first['validator']]
+        SYMBOL_FOR_TYPE[(column_info.first['validator'].split(/[\.(]/) & SYMBOL_FOR_TYPE.keys).first]
       end
 
       def to_cql_value(column, value, table, options={})


### PR DESCRIPTION
[Cassandra list type](http://docs.datastax.com/en/cql/3.0/cql/cql_using/use_list_t.html) does not currently work with this gem. This is due to `get_column_type` method not returning the correct column type (it does not parse the `column_info.first["validator"]` string properly) which this PR fixes. Please see my last comment in issue #59 for more details.