### PR TITLE
Update error messages to point to correct filepath for config/cassandra.yml

### DIFF
--- a/lib/cassandra_migrations/cassandra/keyspace_operations.rb
+++ b/lib/cassandra_migrations/cassandra/keyspace_operations.rb
@@ -37,10 +37,10 @@ module CassandraMigrations
 
       def validate_config(config)
         if config.keyspace.nil?
-          raise Errors::MissingConfigurationError.new("Configuration of 'keyspace' is required in config.yml, but none is defined.")
+          raise Errors::MissingConfigurationError.new("Configuration of 'keyspace' is required in config/cassandra.yml, but none is defined.")
         end
         unless config_includes_replication?(config)
-          raise Errors::MissingConfigurationError.new("Configuration for 'replication' is required in config.yml, but none is defined.")
+          raise Errors::MissingConfigurationError.new("Configuration for 'replication' is required in config/cassandra.yml, but none is defined.")
         end
         true
       end


### PR DESCRIPTION
The error messages in the config validation currently point towards config.yml, but as per the documentation the config file is actually located at config/cassandra.yml.  This fix should clear up some confusion for devs.