### PR TITLE
Add the ability to create keyspaces with NetworkReplicationStrategy

### DIFF
--- a/lib/cassandra_migrations/cassandra/keyspace_operations.rb
+++ b/lib/cassandra_migrations/cassandra/keyspace_operations.rb
@@ -7,21 +7,24 @@ module CassandraMigrations
 
       def create_keyspace!(env)
         config = Config.configurations[env]
-        validate_config(config)
-
-        execute(
-          "CREATE KEYSPACE #{config.keyspace} \
-           WITH replication = { \
-             'class':'#{config.replication['class']}', \
-             'replication_factor': #{config.replication['replication_factor']} \
-           }"
-        )
+        execute(create_keyspace_statement(config))
         begin
           use(config.keyspace)
         rescue StandardErorr => exception
           drop_keyspace!(env)
           raise exception
         end
+      end
+
+      def create_keyspace_statement(config)
+        validate_config(config)
+        <<-CQL.strip_heredoc
+          CREATE KEYSPACE #{config.keyspace}
+          WITH replication = {
+            'class': '#{config.replication['class']}',
+            #{replication_options_statement(config)}
+          }
+        CQL
       end
 
       def drop_keyspace!(env)
@@ -38,17 +41,28 @@ module CassandraMigrations
       def validate_config(config)
         if config.keyspace.nil?
           raise Errors::MissingConfigurationError.new("Configuration of 'keyspace' is required in config/cassandra.yml, but none is defined.")
-        end
-        unless config_includes_replication?(config)
+        elsif config_requires_replication?(config) && !config_includes_replication?(config)
           raise Errors::MissingConfigurationError.new("Configuration for 'replication' is required in config/cassandra.yml, but none is defined.")
         end
         true
+      end
+
+      def config_requires_replication?(config)
+        config.replication['class'] == 'SimpleStrategy'
       end
 
       def config_includes_replication?(config)
         config.replication &&
         config.replication['class'] &&
         config.replication['replication_factor']
+      end
+
+      def replication_options_statement(config)
+        if config.replication['class'] == "SimpleStrategy"
+         "'replication_factor': #{config.replication['replication_factor']}"
+        elsif config.replication['class'] == "NetworkTopologyStrategy"
+          config.replication.reject{ |k,v| k == 'class' }.map { |k,v| "'#{k}': #{v}" }.join(", ")
+        end
       end
     end
   end

--- a/spec/cassandra_migrations/cassandra/keyspace_operations_spec.rb
+++ b/spec/cassandra_migrations/cassandra/keyspace_operations_spec.rb
@@ -1,0 +1,35 @@
+# encoding : utf-8
+require 'spec_helper'
+
+describe CassandraMigrations::Cassandra::KeyspaceOperations do
+
+  describe "#create_keyspace_statement" do
+    let(:config) { CassandraMigrations::Config.configurations[env] }
+    let(:extended_object) { Object.new.extend(described_class) }
+
+    before do
+      allow(Rails).to receive(:root).and_return Pathname.new("spec/fixtures")
+    end
+
+    context "for a SimpleStrategy keyspace" do
+      let(:env) { "test" }
+
+      it "includes the correct CQL statement with replication factor" do
+        expected_statement =  "CREATE KEYSPACE my_keyspace_test\nWITH replication = {\n  'class': 'SimpleStrategy',\n  'replication_factor': 1\n}\n"
+
+        expect(extended_object.create_keyspace_statement(config)).to eq(expected_statement)
+      end
+    end
+
+    context "for a NetworkTopologyStrategy keyspace" do
+      let(:env) { "test_with_network_topology_strategy" }
+
+      it "includes the correct CQL statement with " do
+        expected_statement =  "CREATE KEYSPACE my_keyspace_test_network_topology\nWITH replication = {\n  'class': 'NetworkTopologyStrategy',\n  'testdc': 1, 'dc2': 2\n}\n"
+
+        expect(extended_object.create_keyspace_statement(config)).to eq(expected_statement)
+      end
+    end
+  end
+end
+

--- a/spec/cassandra_migrations/config_spec.rb
+++ b/spec/cassandra_migrations/config_spec.rb
@@ -50,4 +50,22 @@ describe CassandraMigrations::Config do
     allow(Rails).to receive(:env).and_return ActiveSupport::StringInquirer.new("development")
     expect(CassandraMigrations::Config.configurations['production'].keyspace).to eq('cassandra_migrations_production')
   end
+
+  it 'requires replication factor configuration when using replication class SimpleStrategy' do
+    allow(Rails).to receive(:root).and_return Pathname.new("spec/fixtures")
+    allow(Rails).to receive(:env).and_return ActiveSupport::StringInquirer.new("test_with_missing_replication_factor")
+
+    expect {
+      CassandraMigrations::Cassandra.create_keyspace_statement(CassandraMigrations::Config.configurations[Rails.env])
+    }.to raise_exception(CassandraMigrations::Errors::MissingConfigurationError, "Configuration for 'replication' is required in config/cassandra.yml, but none is defined.".red)
+  end
+
+  it 'does not require replication factor configuration when NOT using SimpleStrategy' do
+    allow(Rails).to receive(:root).and_return Pathname.new("spec/fixtures")
+    allow(Rails).to receive(:env).and_return ActiveSupport::StringInquirer.new("test_with_network_topology_strategy")
+
+    expect {
+     CassandraMigrations::Cassandra.create_keyspace_statement(CassandraMigrations::Config.configurations[Rails.env])
+    }.not_to raise_exception
+  end
 end

--- a/spec/fixtures/config/cassandra.yml
+++ b/spec/fixtures/config/cassandra.yml
@@ -16,6 +16,24 @@ test:
     class: 'SimpleStrategy'
     replication_factor: 1
 
+test_with_missing_replication_factor:
+  hosts:
+    - 127.0.0.1
+  port: 9042
+  keyspace: my_keyspace_test
+  replication:
+    class: 'SimpleStrategy'
+
+test_with_network_topology_strategy:
+  hosts:
+    - 127.0.0.1
+  port: 9042
+  keyspace: my_keyspace_test_network_topology
+  replication:
+    class: 'NetworkTopologyStrategy'
+    testdc: 1
+    dc2: 2
+
 production:
   hosts:
     - 'cass1.my_app.biz'


### PR DESCRIPTION
This is a fantastic tool for using `SimpleStrategy` keyspaces in development, but currently does not support using `NetworkTopologyStrategy`.  In our use case, my team wants to use `NetworkTopologyStrategy` for development, both to maintain consistency between environments and to use the same process for keyspace creation and migrations in development and production.  We (me + @cosgroveb) came up with a solution to support configuration for both strategies.

This PR introduces a way to deal with differences in replication options in initial keyspace creation. It gives us the ability to specify a `NetworkTopologyStrategy` with accompanying datacenter-specific replication, while preserving validation surrounding `SimpleStrategy`'s `replication_factor`.

This should also be a good first step towards a solution to issue #76!  Thanks for all of the hard work you've put into this gem, and we hope you'll enjoy this contribution. 🔑 👾 💖 