### PR TITLE
Migration versions and naming

### DIFF
--- a/lib/cassandra_migrations/errors.rb
+++ b/lib/cassandra_migrations/errors.rb
@@ -52,5 +52,11 @@ module CassandraMigrations
       end
     end
 
+    class MigrationNamingError < CassandraError
+      def initialize(msg)
+        super(msg)
+      end
+    end
+
   end
 end

--- a/lib/cassandra_migrations/migrator.rb
+++ b/lib/cassandra_migrations/migrator.rb
@@ -81,11 +81,16 @@ private
     end
 
     def self.get_class_from_migration_name(filename)
-      filename.match(/[0-9]{14}_(.+)\.rb$/).captures.first.camelize.constantize
+      migration_name = filename.match(/[0-9]+_(.+)\.rb$/).captures.first.camelize
+      migration_name.constantize
+    rescue NameError => e
+      raise Errors::MigrationNamingError, "Migration file names must match the class name in the migration—could not find class #{migration_name}."
     end
 
-    def self.get_version_from_migration_name(migration_name)
-      migration_name.match(/([0-9]{14})_.+\.rb$/).captures.first.to_i
+    def self.get_version_from_migration_name(filename)
+      filename.match(/\/([0-9]+)_.+\.rb$/).captures.first.to_i
+    rescue
+      raise Errors::MigrationNamingError, "Migration file names must start with a numeric version prefix."
     end
   end
 end

--- a/spec/cassandra_migrations/migrator_spec.rb
+++ b/spec/cassandra_migrations/migrator_spec.rb
@@ -1,0 +1,43 @@
+# encoding : utf-8
+require 'spec_helper'
+require_relative '../fixtures/db/cassandra_migrate/20160523185719_create_test_table'
+require_relative '../fixtures/db/cassandra_migrate/12345_release_12345'
+
+describe CassandraMigrations::Migrator do
+
+  before do
+    allow(Rails).to receive(:root).and_return Pathname.new("#{Dir.pwd}/spec/fixtures")
+    allow(described_class).to receive(:read_current_version).and_return(0)
+  end
+
+  it "finds and runs all valid migrations" do
+    allow(CassandraMigrations::Cassandra).to receive(:write!).at_least(:twice).with(any_args).and_return(nil)
+
+    expect_any_instance_of(CreateTestTable).to receive(:migrate).with(:up)
+    expect_any_instance_of(Release12345).to receive(:migrate).with(:up)
+
+    described_class.up_to_latest!
+  end
+
+  it "only runs migrations with version numbers greater than those of the previously run migrations" do
+    allow(described_class).to receive(:read_current_version).and_return(23456)
+    allow(CassandraMigrations::Cassandra).to receive(:write!).once.with(any_args).and_return(nil)
+
+    expect_any_instance_of(CreateTestTable).to receive(:migrate).with(:up)
+    expect_any_instance_of(Release12345).not_to receive(:migrate).with(:up)
+
+    described_class.up_to_latest!
+  end
+
+  it "requires the migrations to begin with a version number" do
+    allow(described_class).to receive(:get_all_migration_names).and_return(["#{Dir.pwd}/spec/fixtures/db/cassandra_migrate/no_numbers_here"])
+
+    expect { described_class.up_to_latest! }.to raise_exception(CassandraMigrations::Errors::MigrationNamingError, "Migration file names must start with a numeric version prefix.".red)
+  end
+
+  it "requires the class name of the migration to match the file name" do
+    allow(described_class).to receive(:get_all_migration_names).and_return(["#{Dir.pwd}/spec/fixtures/db/cassandra_migrate/invalid/12345_non_matching_filename.rb"])
+
+    expect { described_class.up_to_latest! }.to raise_exception(CassandraMigrations::Errors::MigrationNamingError, "Migration file names must match the class name in the migration—could not find class NonMatchingFilename.".red)
+  end
+end

--- a/spec/fixtures/db/cassandra_migrate/12345_release_12345.rb
+++ b/spec/fixtures/db/cassandra_migrate/12345_release_12345.rb
@@ -1,0 +1,9 @@
+class Release12345 < CassandraMigrations::Migration
+  def up
+
+  end
+
+  def down
+
+  end
+end

--- a/spec/fixtures/db/cassandra_migrate/20160523185719_create_test_table.rb
+++ b/spec/fixtures/db/cassandra_migrate/20160523185719_create_test_table.rb
@@ -1,0 +1,9 @@
+class CreateTestTable < CassandraMigrations::Migration
+  def up
+
+  end
+
+  def down
+
+  end
+end

--- a/spec/fixtures/db/cassandra_migrate/invalid/12345_non_matching_filename.rb
+++ b/spec/fixtures/db/cassandra_migrate/invalid/12345_non_matching_filename.rb
@@ -1,0 +1,9 @@
+class ThisClassNameDoesntMatchTheFilename < CassandraMigrations::Migration
+  def up
+
+  end
+
+  def down
+
+  end
+end


### PR DESCRIPTION
One more from me and @cosgroveb. ;)

Rails allows us to version migrations outside of the 14-digit version name convention, so we want our Cassandra migrations to have the same flexibility.  This pull requests adds that flexibility, and also provides helpful error messages in the case of a mis-named migration file.  We have also added some testing surrounding the parsing and execution of migration names.

Thanks again, and cheers!