### PR TITLE
Fix handling ints for non-nested hash (table option)

### DIFF
--- a/lib/cassandra_migrations/migration/table_definition.rb
+++ b/lib/cassandra_migrations/migration/table_definition.rb
@@ -247,8 +247,11 @@ module CassandraMigrations
           when :compact_storage
             cql_name
           else
-            value_str = value.map {|k, v| "'#{k}':'#{v}'"}.join(',')
-            "#{cql_name} = {#{value_str}}"
+            #if complex option with nested hash, convert keys and values to proper string value
+            if value.is_a?(Hash)
+              value = "{#{value.map {|k, v| "'#{k}':'#{v}'"}.join(',')}}"
+            end
+            "#{cql_name} = #{value}"
         end
       end
 

--- a/spec/cassandra_migrations_spec.rb
+++ b/spec/cassandra_migrations_spec.rb
@@ -282,6 +282,18 @@ describe CassandraMigrations do
       end
     end
 
+    context 'with multiple nested properties' do
+      before do
+        @migration = WithMultipleNestedPropertiesMigration.new
+      end
+
+      it 'should produce a valid CQL create statement' do
+        @migration.up
+        expected_cql = "CREATE TABLE collection_lists (id uuid, a_decimal decimal, PRIMARY KEY(id)) WITH compression = {'sstable_compression':'DeflateCompressor','chunk_length_kb':'64'} AND compaction = {'class':'LeveledCompactionStrategy'}"
+        expect(@migration.cql).to eq(expected_cql)
+      end
+    end
+
     context 'using a different keyspace' do
       before do
         @migration = WithAlternateKeyspaceMigration.new

--- a/spec/fixtures/migrations/migrations.rb
+++ b/spec/fixtures/migrations/migrations.rb
@@ -195,6 +195,15 @@ class WithPropertyMigration < CassandraMigrations::Migration
   end
 end
 
+class WithMultipleNestedPropertiesMigration < CassandraMigrations::Migration
+  def up
+    create_table :collection_lists, options: {compression: {sstable_compression: 'DeflateCompressor', chunk_length_kb: 64}, compaction: {class: 'LeveledCompactionStrategy'}} do |t|
+      t.uuid :id, :primary_key => true
+      t.decimal :a_decimal
+    end
+  end
+end
+
 class WithAlternateKeyspaceMigration < CassandraMigrations::Migration
   def up
     using_keyspace('alternative') do


### PR DESCRIPTION
`.map` is called on value of options passed in from `create_table` so
that complex nested hash options can be parsed into proper Cassandra
syntax. However, this caused integer values on simple non-nested hash
options to break as `.map` was being called on these integer values. See
PR #77.

Change logic to check that value is a hash (indicating that a nested
hash was passed into options) before parsing it into a hash with string
keys and values. If it isn't then use the value as is.

Add tests for PR #77.